### PR TITLE
feat(swagger): add Swagger support and document rental API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,16 @@
 			<scope>test</scope>
 		</dependency>
 
+    <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        <version>2.8.9</version>
+    </dependency>
+    <!-- <dependency> -->
+    <!--     <groupId>io.springfox</groupId> -->
+    <!--     <artifactId>springfox-boot-starter</artifactId> -->
+    <!--     <version>3.0.0</version> -->
+    <!-- </dependency> -->
     <!-- <dependency> -->
     <!--   <groupId>io.jsonwebtoken</groupId> -->
     <!--   <artifactId>jjwt-api</artifactId> -->

--- a/src/main/java/com/openclassrooms/configuration/SecurityConfig.java
+++ b/src/main/java/com/openclassrooms/configuration/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(auth -> auth
+        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
         .requestMatchers("/api/auth/login", "/api/auth/register", "/images/*").permitAll()
         .anyRequest().authenticated())
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))

--- a/src/main/java/com/openclassrooms/configuration/SwaggerConfig.java
+++ b/src/main/java/com/openclassrooms/configuration/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.openclassrooms.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("ChâTop API")
+            .version("1.0")
+            .description("API de location immobilière"))
+        .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+        .components(new Components()
+            .addSecuritySchemes("Bearer Authentication",
+                new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")));
+  }
+
+}

--- a/src/main/java/com/openclassrooms/controller/AppUserController.java
+++ b/src/main/java/com/openclassrooms/controller/AppUserController.java
@@ -10,10 +10,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.openclassrooms.dto.response.AppUserResponse;
+import com.openclassrooms.dto.response.BaseResponse;
 import com.openclassrooms.dto.response.SimpleResponse;
 import com.openclassrooms.service.AppUserService;
 
 import jakarta.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @RestController
 @RequestMapping("/api/user")
@@ -23,7 +30,10 @@ public class AppUserController {
   private AppUserService appUserService;
 
   @GetMapping(value = "/{id}", produces = "application/json")
-  public ResponseEntity<?> user(@PathVariable Integer id) {
+  @Operation(summary = "Get a user information")
+  @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = AppUserResponse.class)))
+  @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = SimpleResponse.class)))
+  public ResponseEntity<BaseResponse> user(@PathVariable Integer id) {
     try {
       AppUserResponse response = appUserService.getUser(id);
       return ResponseEntity.ok(response);

--- a/src/main/java/com/openclassrooms/controller/AuthController.java
+++ b/src/main/java/com/openclassrooms/controller/AuthController.java
@@ -16,9 +16,15 @@ import com.openclassrooms.dto.request.LoginRequest;
 import com.openclassrooms.dto.request.RegisterRequest;
 import com.openclassrooms.dto.response.AppUserResponse;
 import com.openclassrooms.dto.response.AuthResponse;
+import com.openclassrooms.dto.response.BaseResponse;
 import com.openclassrooms.dto.response.SimpleResponse;
 import com.openclassrooms.service.AppUserService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 
 @RestController
@@ -29,7 +35,11 @@ public class AuthController {
   private AppUserService appUserService;
 
   @PostMapping(value = "/register", produces = "application/json")
-  public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest request) {
+  @Operation(summary = "Register a new user")
+  @SecurityRequirements({})
+  @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = AuthResponse.class)))
+  @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = SimpleResponse.class)))
+  public ResponseEntity<BaseResponse> register(@Valid @RequestBody RegisterRequest request) {
     try {
       String jwtToken = appUserService.register(request);
       return ResponseEntity.ok(new AuthResponse(jwtToken));
@@ -39,10 +49,13 @@ public class AuthController {
   }
 
   @PostMapping(value = "/login", produces = "application/json")
-  public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
+  @Operation(summary = "Authenticate a registered user")
+  @SecurityRequirements({})
+  @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = AuthResponse.class)))
+  @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = SimpleResponse.class)))
+  public ResponseEntity<BaseResponse> login(@Valid @RequestBody LoginRequest request) {
     try {
       String jwtToken = appUserService.login(request);
-      System.out.println("Login OK");
       return ResponseEntity.ok(new AuthResponse(jwtToken));
     } catch (Exception e) {
       return ResponseEntity.badRequest().body(new SimpleResponse(e.getMessage()));
@@ -50,18 +63,15 @@ public class AuthController {
   }
 
   @GetMapping(value = "/me", produces = "application/json")
-  public ResponseEntity<?> me(@AuthenticationPrincipal Jwt jwt) {
-    // System.out.println("Me called");
+  @Operation(summary = "Get authenticated user information")
+  @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = AppUserResponse.class)))
+  @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = SimpleResponse.class)))
+  public ResponseEntity<BaseResponse> me(@AuthenticationPrincipal Jwt jwt) {
     try {
-      // System.out.println("Step 1");
       Integer userId = ((Number) jwt.getClaim("userId")).intValue();
-      // System.out.println("Step 2");
       AppUserResponse appUserResponse = appUserService.getUser(userId);
-      // System.out.println("Step 3");
-      // System.out.println("Me succeed for user "+userId.toString());
       return ResponseEntity.ok(appUserResponse);
     } catch (Exception e) {
-      System.out.println("plantage " + e.getMessage());
       return ResponseEntity.badRequest().body(new SimpleResponse(e.getMessage()));
     }
   }

--- a/src/main/java/com/openclassrooms/controller/MessageController.java
+++ b/src/main/java/com/openclassrooms/controller/MessageController.java
@@ -10,10 +10,17 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import com.openclassrooms.dto.request.MessageRequest;
+import com.openclassrooms.dto.response.BaseResponse;
 import com.openclassrooms.dto.response.SimpleResponse;
 import com.openclassrooms.service.MessageService;
 
 import jakarta.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @RestController
 @RequestMapping("/api")
@@ -27,12 +34,13 @@ public class MessageController {
   }
 
   @PostMapping(value = "/messages", produces = "application/json")
-  public ResponseEntity<?> postMessage(
+  @Operation(summary = "Send a message to a owner")
+  @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = SimpleResponse.class)))
+  @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = SimpleResponse.class)))
+  public ResponseEntity<BaseResponse> postMessage(
       @Valid @RequestBody MessageRequest request,
       @AuthenticationPrincipal Jwt jwt
       ) {
-
-    System.out.println("Enter the /api/messages route");
 
     Integer userId = ((Number) jwt.getClaim("userId")).intValue();
 
@@ -40,7 +48,6 @@ public class MessageController {
       messageService.saveMessage(request, userId); 
       return ResponseEntity.ok(new SimpleResponse("Message send with success"));
     } catch (Exception e) {
-      System.out.println(e.getMessage());
       return ResponseEntity.badRequest().body(new SimpleResponse("Impossible d’envoyer ce message"));
     }
   }

--- a/src/main/java/com/openclassrooms/dto/request/RentalRequest.java
+++ b/src/main/java/com/openclassrooms/dto/request/RentalRequest.java
@@ -2,11 +2,15 @@ package com.openclassrooms.dto.request;
 
 import java.math.BigDecimal;
 
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Rental creation data")
 public class RentalRequest {
 
   public RentalRequest() {
@@ -28,6 +32,10 @@ public class RentalRequest {
   @NotBlank(message = "Veuillez saisir une description")
   @Size(max = 2000, message = "La description doit contenir au maximum 2000 caractères")
   private String description;
+
+  @Schema(description = "Rental picture", type = "string", format = "binary")
+  @NotNull(message = "L’image est obligatoire")
+  private MultipartFile picture;
 
   public String getName() {
     return name;
@@ -61,6 +69,11 @@ public class RentalRequest {
     this.description = description;
   }
 
+  public MultipartFile getPicture() {
+    return picture;
+  }
 
-
+  public void setPicture(MultipartFile picture) {
+    this.picture = picture;
+  }
 }

--- a/src/main/java/com/openclassrooms/dto/response/AppUserResponse.java
+++ b/src/main/java/com/openclassrooms/dto/response/AppUserResponse.java
@@ -7,7 +7,7 @@ import java.time.format.DateTimeFormatter;
 import com.openclassrooms.model.AppUser;
 import com.openclassrooms.util.DateUtils;
 
-public class AppUserResponse {
+public class AppUserResponse extends BaseResponse {
 
   private Integer id;
   private String email;

--- a/src/main/java/com/openclassrooms/dto/response/AuthResponse.java
+++ b/src/main/java/com/openclassrooms/dto/response/AuthResponse.java
@@ -1,6 +1,6 @@
 package com.openclassrooms.dto.response;
 
-public class AuthResponse {
+public class AuthResponse extends BaseResponse {
 
   private String token;
 

--- a/src/main/java/com/openclassrooms/dto/response/BaseResponse.java
+++ b/src/main/java/com/openclassrooms/dto/response/BaseResponse.java
@@ -1,0 +1,9 @@
+package com.openclassrooms.dto.response;
+
+public class BaseResponse {
+
+  public BaseResponse() {
+
+  }
+
+}

--- a/src/main/java/com/openclassrooms/dto/response/RentalListResponse.java
+++ b/src/main/java/com/openclassrooms/dto/response/RentalListResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.openclassrooms.model.Rental;
 
-public class RentalListResponse {
+public class RentalListResponse extends BaseResponse {
 
   private List<RentalResponse> rentals;
 

--- a/src/main/java/com/openclassrooms/dto/response/RentalResponse.java
+++ b/src/main/java/com/openclassrooms/dto/response/RentalResponse.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 import com.openclassrooms.model.Rental;
 import com.openclassrooms.util.DateUtils;
 
-public class RentalResponse {
+public class RentalResponse extends BaseResponse {
 
   private Integer id;
   private String name;

--- a/src/main/java/com/openclassrooms/dto/response/SimpleResponse.java
+++ b/src/main/java/com/openclassrooms/dto/response/SimpleResponse.java
@@ -3,7 +3,7 @@ package com.openclassrooms.dto.response;
 /**
  * This is a DTO class for error response
  */
-public class SimpleResponse {
+public class SimpleResponse extends BaseResponse {
 
     private String message;
 


### PR DESCRIPTION
- add springdoc-openapi-starter-webmvc-ui dependency
- document POST /api/rentals using multipart/form-data with @ModelAttribute
- update RentalRequest DTO to include picture (MultipartFile)
- introduce BaseResponse as a parent class for API responses
- replace ResponseEntity<?> with ResponseEntity<BaseResponse>
- remove obsolete debug print statements